### PR TITLE
3주차 - BaekJoon 14248번: 점프 점프

### DIFF
--- a/Hyeyeong/src/week3/BaekJoon14248.kt
+++ b/Hyeyeong/src/week3/BaekJoon14248.kt
@@ -1,0 +1,38 @@
+import java.util.LinkedList
+import java.util.Queue
+import java.util.Scanner
+import kotlin.math.abs
+
+fun main() {
+    val scanner = Scanner(System.`in`)
+    val n = scanner.nextInt()
+    val inputArray = IntArray(n) { scanner.nextInt() }
+    val start = scanner.nextInt() - 1
+    val visited = BooleanArray(n)
+
+    fun bfs(start: Int) {
+        val queue: Queue<Int> = LinkedList()
+        queue.add(start)
+        visited[start] = true
+
+        while (queue.isNotEmpty()) {
+            val currentIndex = queue.poll()
+            val currentValue = abs(inputArray[currentIndex])
+
+            val leftIndex = currentIndex - currentValue
+            if (leftIndex >= 0 && !visited[leftIndex]) {
+                visited[leftIndex] = true
+                queue.add(leftIndex)
+            }
+
+            val rightIndex = currentIndex + currentValue
+            if (rightIndex < n && !visited[rightIndex]) {
+                visited[rightIndex] = true
+                queue.add(rightIndex)
+            }
+        }
+    }
+    bfs(start)
+    val answer = visited.count { it }
+    println(answer)
+}

--- a/Hyeyeong/src/week3/BaekJoon2644.kt
+++ b/Hyeyeong/src/week3/BaekJoon2644.kt
@@ -26,14 +26,12 @@ fun bfs(p1: Int, p2: Int, arr: Array<MutableList<Int>>, n: Int): Int {
 }
 
 fun main() {
-    //만약 아예 연관없는 촌수라면? -1 출력
     val scanner = Scanner(System.`in`)
     val n = scanner.nextInt()
     val p1 = scanner.nextInt()
     val p2 = scanner.nextInt()
     val relationCount = scanner.nextInt()
     val relationArray = Array(n + 1) { mutableListOf<Int>() } //사촌 배열
-    //IntArray는 1차원 배열만 생성 가능하다. 그래서 처음에 감쌀때는 Array로 감싸줘야한다.
 
     repeat(relationCount) {
         val a1 = scanner.nextInt()

--- a/Hyeyeong/src/week3/BaekJoon2644.kt
+++ b/Hyeyeong/src/week3/BaekJoon2644.kt
@@ -1,0 +1,47 @@
+import java.util.LinkedList
+import java.util.Queue
+import java.util.Scanner
+
+fun bfs(p1: Int, p2: Int, arr: Array<MutableList<Int>>, n: Int): Int {
+    val queue: Queue<Int> = LinkedList()
+    val visited = IntArray(n + 1) { 0 }
+
+    queue.add(p1)
+    visited[p1] = 1
+
+    while (queue.isNotEmpty()) {
+        val current = queue.poll()
+        if (current == p2) {
+            return visited[p2] - 1
+        }
+
+        for (next in arr[current]) {
+            if (visited[next] == 0) {
+                queue.add(next)
+                visited[next] = visited[current] + 1
+            }
+        }
+    }
+    return -1
+}
+
+fun main() {
+    //만약 아예 연관없는 촌수라면? -1 출력
+    val scanner = Scanner(System.`in`)
+    val n = scanner.nextInt()
+    val p1 = scanner.nextInt()
+    val p2 = scanner.nextInt()
+    val relationCount = scanner.nextInt()
+    val relationArray = Array(n + 1) { mutableListOf<Int>() } //사촌 배열
+    //IntArray는 1차원 배열만 생성 가능하다. 그래서 처음에 감쌀때는 Array로 감싸줘야한다.
+
+    repeat(relationCount) {
+        val a1 = scanner.nextInt()
+        val b1 = scanner.nextInt()
+        relationArray[a1].add(b1)
+        relationArray[b1].add(a1)
+    }
+
+    val answer = bfs(p1, p2, relationArray, n)
+    println(answer)
+}


### PR DESCRIPTION
## 이슈사항
### 1. 런타임에러
원인:  `Split(" ")`으로 문자를 받으면 런타임에러발생. 검색해보니 numberFormatException 발생하는거같습니다. 
해결: `Scanner(System.`in`)`로 입력값 받아옴

### 2. Queue 사용
원인:  BFS 강의 찾아보니 BFS 문제 풀 때,  Queue를 많이 쓰는걸 이제 알았습니다. (mutableList 쓴거같은데 여러분 답답하게해서 죄송죄송 )
해결: Queue 사용하여 풀이. 추후에 BFS 문제 나오면 Queue로  해결해보겠습니다. 