### PR TITLE
4주차 - BaekJoon 7576번 : 토마토

### DIFF
--- a/Gayeong/src/week4/BaekJoon7576.java
+++ b/Gayeong/src/week4/BaekJoon7576.java
@@ -1,0 +1,71 @@
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class 토마토 {
+    static int n, m;
+    static int[][] graph;
+    static Queue<Node> queue = new LinkedList<>();
+
+    static int[] dx = {1, -1, 0, 0};
+    static int[] dy = {0, 0, 1, -1};
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        n = sc.nextInt();
+        m = sc.nextInt();
+        sc.nextLine();
+        graph = new int[m][n];
+
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                graph[i][j] = sc.nextInt();
+
+                if (graph[i][j] == 1) queue.offer(new Node(i, j));
+            }
+            sc.nextLine();
+        }
+
+        bfs();
+
+        int result = 0;
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                if (graph[i][j] == 0) {
+                    System.out.println(-1);
+                    return;
+                } else {
+                    result = Math.max(result, graph[i][j]);
+                }
+            }
+        }
+
+        System.out.println(result - 1);
+    }
+
+    static class Node {
+        int x;
+        int y;
+
+        public Node(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+    static void bfs() {
+        while (!queue.isEmpty()) {
+            Node cur = queue.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nx = cur.x + dx[i];
+                int ny = cur.y + dy[i];
+
+                if (nx < 0 || nx >= m || ny < 0 || ny >= n || graph[nx][ny] != 0) continue;
+
+                queue.offer(new Node(nx, ny));
+                graph[nx][ny] = graph[cur.x][cur.y] + 1;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### 첫 번째 시도 : ❌메모리 초과 ❌
입력받은 graph의 값이 1인 정점마다 bfs를 돌았다.
-> 정점이 n개인 경우 bfs를 n번 돌아야 하고 queue도 n번 생성해야 함.

### 해결 : graph를 입력받을 때 1인 정점을 queue에 담는다.
이렇게 하면 각 정점마다 bfs를 돌 필요도 없으며, **무엇보다 탐색해야 하는 다음 정점의 값이 현재 정점보다 작거나 같은지를 확인해줄 필요가 없다. (=> 단순히 방문 체크만 하면 됨)**
