### PR TITLE
4주차 - BaekJoon 1240 : 노드사이의 거리

### DIFF
--- a/Gayeong/src/week4/BaekJoon1240.java
+++ b/Gayeong/src/week4/BaekJoon1240.java
@@ -1,9 +1,11 @@
+package BFS;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Scanner;
 
 public class BaekJoon1240 {
+
     static int n;
     static int m;
     static ArrayList<Edge>[] graph;
@@ -47,18 +49,18 @@ public class BaekJoon1240 {
     static int  bfs(int start, int end) {
         Queue<Edge> queue = new LinkedList<>();
         queue.offer(new Edge(start, 0));
-        boolean[] visited = new boolean[n + 1];
-        visited[start] = true;
+        int[] visited = new int[n + 1];
+        visited[start] = 0;
 
         while (!queue.isEmpty()) {
             Edge cur = queue.poll();
 
-            if (cur.v == end) return cur.weight;
+            if (cur.v == end) return visited[cur.v];
 
             for (Edge edge : graph[cur.v]) {
-                if (!visited[edge.v]) {
-                    visited[edge.v] = true;
-                    queue.offer(new Edge(edge.v, cur.weight + edge.weight));
+                if (visited[edge.v] == 0) {
+                    visited[edge.v] = edge.weight + visited[cur.v];
+                    queue.offer(edge);
                 }
             }
         }

--- a/Gayeong/src/week4/BaekJoon1240.java
+++ b/Gayeong/src/week4/BaekJoon1240.java
@@ -1,0 +1,70 @@
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class BaekJoon1240 {
+    static int n;
+    static int m;
+    static ArrayList<Edge>[] graph;
+
+    static class Edge {
+        int v, weight;
+
+        Edge(int v, int weight) {
+            this.v = v;
+            this.weight = weight;
+        }
+    }
+
+    public static void main(String[] agrs) {
+        Scanner sc = new Scanner(System.in);
+        n = sc.nextInt();
+        m = sc.nextInt();
+        sc.nextLine();
+
+        graph = new ArrayList[n + 1];
+        for (int i = 1; i <= n; i++) graph[i] =  new ArrayList<>();
+
+
+        for (int i = 0; i < n-1; i++) {
+            int u = sc.nextInt();
+            int v = sc.nextInt();
+            int w = sc.nextInt();
+
+            graph[u].add(new Edge(v, w));
+            graph[v].add(new Edge(u, w));
+        }
+
+        for (int i = 0; i < m; i++) {
+            int u = sc.nextInt();
+            int v = sc.nextInt();
+
+            System.out.println(bfs(u, v));
+        }
+    }
+
+    static int  bfs(int start, int end) {
+        Queue<Edge> queue = new LinkedList<>();
+        queue.offer(new Edge(start, 0));
+        boolean[] visited = new boolean[n + 1];
+        visited[start] = true;
+
+        while (!queue.isEmpty()) {
+            Edge cur = queue.poll();
+
+            if (cur.v == end) return cur.weight;
+
+            for (Edge edge : graph[cur.v]) {
+                if (!visited[edge.v]) {
+                    visited[edge.v] = true;
+                    queue.offer(new Edge(edge.v, cur.weight + edge.weight));
+                }
+            }
+        }
+
+        return -1;
+    }
+
+
+}


### PR DESCRIPTION
## 최단 거리 갱신 방법에 따른 효율성

이번 문제에선 각 간선에 가중치가 다르게 주어졌기 때문에 아래와 같이 Edge를 클래스를 정의하여 (vertex, weight)를 표현했습니다.
두 가지 방식으로 최단 거지 갱신 방법을 비교하였으며, 이를 통해 **메모리와 시간 측면에서 차이**를 확인할 수 있었습니다.

```java
static class Edge {
        int v, weight;

        Edge(int v, int weight) {
            this.v = v;
            this.weight = weight;
        }
    }

``` 

### 1. Edge 객체를 사용하여 가중치 갱신
이 방식에서는 각 노드를 방문할 때마다 Edge 객체에 가중치를 갱신하고, 이를 큐에 저장하는 방식으로 최단 거리를 계산합니다. 이때 visited는 단순히 방문 여부만 체크합니다.

- 메모리 : 62712KB
- 시간 : 520ms

```java
static int bfs(int start, int end) {
    Queue<Edge> queue = new LinkedList<>();
    boolean[] visited = new boolean[n + 1];
    queue.offer(new Edge(start, 0));
    visited[start] = true;

    while (!queue.isEmpty()) {
        Edge cur = queue.poll();

        if (cur.v == end) {
            return cur.weight;
        }

        for (Edge edge : graph[cur.v]) {
            if (!visited[edge.v]) {
                visited[edge.v] = true;
                queue.offer(new Edge(edge.v, cur.weight + edge.weight));
            }
        }
    }

    return -1;
}
``` 

### 2. visited 배열을 사용하여 최단 거리 갱신
이 방식에서는 visited 배열을 사용하여 각 노드의 최단 거리를 직접 갱신합니다. 방문한 노드를 큐에 넣을 때마다 해당 노드의 가중치를 갱신하고, 이 값을 최단 거리로 사용합니다.

- 메모리 : 49300KB
- 시간 : 476ms

visited 리스트를 이용하여 해당 정점의 최단 거리를 갱신했습니다. 
```java
static int bfs(int start, int end) {
    Queue<Edge> queue = new LinkedList<>();
    queue.offer(new Edge(start, 0));
    int[] visited = new int[n + 1];
    visited[start] = 0;

    while (!queue.isEmpty()) {
        Edge cur = queue.poll();

        if (cur.v == end) return visited[cur.v];

        for (Edge edge : graph[cur.v]) {
            if (visited[edge.v] == 0) {
                visited[edge.v] = edge.weight + visited[cur.v];
                queue.offer(edge);
            }
        }
    }

    return -1;
}
``` 

### 3. 결론
- 메모리 측면 : Edge 객체를 큐에 저장하는 방식은 매번 Edge 객체를 새로 생성하기 때문에 메모리 사용량이 더 높았던 것 같습니다.
- 시간 측면 : 아무래도 Edge 객체를 생성하지 않고 바로 visited 배열을 갱신하기 때문에 더 짧은 시간이 소요된 것 같습니다.
