### PR TITLE
4주차 - BaekJoon 1240번 : 노드사이의 거리

### DIFF
--- a/Soobeen/src/week4/BaekJoon1240.kt
+++ b/Soobeen/src/week4/BaekJoon1240.kt
@@ -1,0 +1,45 @@
+package week4
+
+import java.util.*
+
+fun main() {
+    val (N, M) = readln().split(" ").map { it.toInt() }
+    val matrix = Array(N + 1) { Array(N + 1) { 0 } }
+    val adj = Array(N + 1) { mutableListOf<Int>() }
+    val stack = Stack<Int>()
+
+    repeat(N-1) {
+        val line = readln().split(" ").map { it.toInt() }
+        val start = line[0]
+        val end = line[1]
+        val distance = line[2]
+
+        adj[start].add(end)
+        adj[end].add(start)
+
+        matrix[start][end] = distance
+        matrix[end][start] = distance
+    }
+
+    repeat(M) {
+        val visited = mutableListOf<Int>()
+        var distance = 0
+        var prev = 0
+        val (start, end) = readln().split(" ").map { it.toInt() }
+
+        visited.add(start)
+        stack.push(start)
+
+        while(stack.isNotEmpty()) {
+            val current = stack.pop()
+            val nextList = adj[current]
+            visited.add(current)
+
+            for (next in nextList) {
+                if (next in visited) continue
+                stack.push(next)
+            }
+            prev = current
+        }
+    }
+}

--- a/Soobeen/src/week4/BaekJoon1240.kt
+++ b/Soobeen/src/week4/BaekJoon1240.kt
@@ -4,42 +4,40 @@ import java.util.*
 
 fun main() {
     val (N, M) = readln().split(" ").map { it.toInt() }
-    val matrix = Array(N + 1) { Array(N + 1) { 0 } }
-    val adj = Array(N + 1) { mutableListOf<Int>() }
-    val stack = Stack<Int>()
+    val pQueue: Queue<Pair<Int, Int>> = PriorityQueue(compareBy { it.first }) // 거리, 정점
+    val distanceMatrix = Array(N + 1) { Array(N + 1) { 0 } }
+    val adjMatrix = Array(N + 1) { mutableListOf<Int>() }
 
     repeat(N-1) {
-        val line = readln().split(" ").map { it.toInt() }
-        val start = line[0]
-        val end = line[1]
-        val distance = line[2]
+        val (start, end, distance) = readln().split(" ").map { it.toInt() }
 
-        adj[start].add(end)
-        adj[end].add(start)
+        adjMatrix[start].add(end)
+        adjMatrix[end].add(start)
 
-        matrix[start][end] = distance
-        matrix[end][start] = distance
+        distanceMatrix[start][end] = distance
+        distanceMatrix[end][start] = distance
     }
 
     repeat(M) {
-        val visited = mutableListOf<Int>()
-        var distance = 0
-        var prev = 0
+        val distances = Array(N + 1) { Integer.MAX_VALUE }
         val (start, end) = readln().split(" ").map { it.toInt() }
+        distances[start] = 0
+        pQueue.add(0 to start)
 
-        visited.add(start)
-        stack.push(start)
+        while (pQueue.isNotEmpty()) {
+            val poll = pQueue.poll()
+            val distance = poll.first
+            val current = poll.second
 
-        while(stack.isNotEmpty()) {
-            val current = stack.pop()
-            val nextList = adj[current]
-            visited.add(current)
+            if (distances[current] != distance) continue
+            for (next in adjMatrix[current]) {
+                if (distances[next] < distances[current] + distanceMatrix[current][next]) continue
 
-            for (next in nextList) {
-                if (next in visited) continue
-                stack.push(next)
+                distances[next] = distances[current] + distanceMatrix[current][next]
+                pQueue.add(distances[next] to next)
             }
-            prev = current
         }
+
+        println(distances[end])
     }
 }


### PR DESCRIPTION
## 문제 풀이 방식

총 두 개의 방식으로 문제를 풀었습니다.

[BFS 알고리즘으로 풀이](https://github.com/Kotlin-Algorithm/CodingTest/pull/27/commits/87c5e4a7f197f9411d9fa58ecbdd6ffdf6216079)
[다익스트라 알고리즘으로 풀이](https://github.com/Kotlin-Algorithm/CodingTest/pull/27/commits/0c0fc3c24619c37e0cea75c4f3d1f1dea47247a4)

첫번째로 BFS 알고리즘을 선택해서 문제를 풀었는데, 모든 테스트 케이스가 실패했습니다. 대부분 BFS 문제는 간선의 가중치가 1인 반면, 이 문제는 간선의 가중치가 랜덤이였습니다. 따라서 인접한 정점들로 이동할 때 각각의 정점마다 비용을 업데이트 해줘야 한다고 생각을 헀는데 어떤 방식으로 풀지 감이 안 잡혔습니다...

그래서 두 번째 방법으로 다익스트라 알고리즘을 선택을 했는데, 문제에서는 두 노드 사이의 "최단"경로를 구하라고는 안 헀지만 어쨋든 간선의 가중치를 주고 경로를 구할 수 있는 알고리즘이 다익스트라가 있다는 것을 기억하고 [바킹독 영상](https://www.youtube.com/watch?v=o9BnvwgPT-o&t=12s)으로 개념을 배우고 이 문제에 적용해봤습니다.

문제는 풀었는데 메모리 : 143300KB, 시간 1168ms 정도로 걸려서 너무 비효율적인 것 같습니다.... 다른 분들 어떻게 푸셨는지 보고 배우겠습니다~


## 공부한 부분
다익스트라 알고리즘
우선 순위 큐 자료구조
코틀린 우선순위 큐 생성자, 람다 함수, Int Class의 compareTo byte code 확인, JVM 

